### PR TITLE
fix CookieJar process set cookie when value has `=` & HttpClient support custom headers.Cookie

### DIFF
--- a/src/lib/tiktokHttpClient.js
+++ b/src/lib/tiktokHttpClient.js
@@ -7,6 +7,12 @@ const Config = require('./webcastConfig.js');
 
 class TikTokHttpClient {
     constructor(customHeaders, axiosOptions, sessionId) {
+        const { Cookie } = customHeaders || {};
+
+        if (Cookie) {
+            delete customHeaders['Cookie'];
+        }
+
         this.axiosInstance = axios.create({
             timeout: 10000,
             headers: {
@@ -17,6 +23,10 @@ class TikTokHttpClient {
         });
 
         this.cookieJar = new TikTokCookieJar(this.axiosInstance);
+
+        if (Cookie) {
+            Cookie.split('; ').forEach((v) => this.cookieJar.processSetCookieHeader(v));
+        }
 
         if (sessionId) {
             this.setSessionId(sessionId);


### PR DESCRIPTION
1. fix CookieJar process set cookie when value has `=`
2. fix CookieJar get cookie string, cookie join with `; `
3. remove cookie value encode while server give cookie value
4. HttpClient support custom headers.Cookie