### PR TITLE
Use modern syntax for node module imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { EventEmitter } = require('events');
+const { EventEmitter } = require('node:events');
 
 const TikTokHttpClient = require('./lib/tiktokHttpClient.js');
 const WebcastWebsocket = require('./lib/webcastWebsocket.js');

--- a/src/lib/webcastProtobuf.js
+++ b/src/lib/webcastProtobuf.js
@@ -1,6 +1,6 @@
 const protobufjs = require('protobufjs');
-const util = require('util');
-const zlib = require('zlib');
+const util = require('node:util');
+const zlib = require('node:zlib');
 const unzip = util.promisify(zlib.unzip);
 
 let tiktokSchemaPath = require.resolve('../proto/tiktokSchema.proto');


### PR DESCRIPTION
`node:` protocol imports are supported in Node 12.20.0 and up. They are recommended to be used this way, especially since Node 14. Some services, like [cloudflare workers](https://developers.cloudflare.com/workers/runtime-apis/nodejs/) require this syntax to be used, or the imports break.

This PR just updates the "bad" imports I found. This will make no real difference to most, but will help compatibility for some.