### PR TITLE
fix(ws-client): remove recursive emit('close') from onDisconnect handler

### DIFF
--- a/src/lib/ws/lib/ws-client.ts
+++ b/src/lib/ws/lib/ws-client.ts
@@ -74,7 +74,6 @@ export default class TikTokWsClient extends (WebSocket as TypedWebSocket) {
     protected onDisconnect() {
         clearInterval(this.pingInterval);
         this.pingInterval = null;
-        this.emit('close');
     }
 
     /**


### PR DESCRIPTION
## Fix recursion in ws-client close event

This PR removes a recursive call to `emit('close')` from the `onDisconnect` handler in `TikTokWsClient`. The change prevents an infinite event loop when the WebSocket `'close'` event is triggered.

**Summary of changes:**
- Removed `this.emit('close')` from `onDisconnect`

This resolves a stack overflow risk and improves event handling reliability.