### PR TITLE
Add Support for TikTok Super Fan Box Events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ publish.ts
 pnpm-lock.yaml
 test-decoding.ts
 unzip-test.ts
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ connection.on(ControlEvent.CONNECTED, () => console.log("Connected!"));
 - [`WebcastEvent.ROOM_VERIFY`](#roomverify) or `"roomVerify"`
 - [`WebcastEvent.LINK_LAYER`](#linklayer) or `"linkLayer"`
 - [`WebcastEvent.ROOM_PIN`](#roompin) or `"roomPin"`
+- [`WebcastEvent.SUPER_FAN`](#superfan) or `"superFan"`
+- [`WebcastEvent.SUPER_FAN_BOX`](#superfanbox) or `"superFanBox"`
 
 ## Control Events
 
@@ -565,6 +567,16 @@ Triggers when a user becomes a Super Fan.
 ```ts
 connection.on(WebcastEvent.SUPER_FAN, (data) => {
     console.log('A user became a superfan!');
+});
+```
+
+### `superFanBox`
+
+Triggers when a user sends a Super Fan Box.
+
+```ts
+connection.on(WebcastEvent.SUPER_FAN_BOX, (data) => {
+    console.log('A Super Fan Box was sent!', data.envelopeInfo);
 });
 ```
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -574,13 +574,11 @@ export class TikTokLiveConnection extends (EventEmitter as new () => TypedEventE
         switch (type) {
 
             case 'WebcastSocialMessage':
-                const socialDisplayType = data.common?.displayText?.displayType?.toLowerCase() || '';
-
-                if (socialDisplayType.includes('follow')) {
+                if (data.common.displayText.displayType?.includes('follow')) {
                     return this.emit(WebcastEvent.FOLLOW, data);
                 }
 
-                if (socialDisplayType.includes('share')) {
+                if (data.common.displayText.displayType?.includes('share')) {
                     return this.emit(WebcastEvent.SHARE, data);
                 }
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -30,7 +30,7 @@ import {
     WebcastEvent,
     WebcastEventMap
 } from '@/types/events';
-import { ControlAction, ProtoMessageFetchResult, WebcastBarrageMessage } from '@/types';
+import { ControlAction, ProtoMessageFetchResult, EnvelopeBusinessType } from '@/types';
 import { WebcastRoomChatRouteResponse } from '@eulerstream/euler-api-sdk';
 
 // Backwards-compatible type for sendMessage options (SDK type no longer includes these fields)
@@ -574,12 +574,13 @@ export class TikTokLiveConnection extends (EventEmitter as new () => TypedEventE
         switch (type) {
 
             case 'WebcastSocialMessage':
+                const socialDisplayType = data.common?.displayText?.displayType?.toLowerCase() || '';
 
-                if (data.common.displayText.displayType?.includes('follow')) {
+                if (socialDisplayType.includes('follow')) {
                     return this.emit(WebcastEvent.FOLLOW, data);
                 }
 
-                if (data.common.displayText.displayType?.includes('share')) {
+                if (socialDisplayType.includes('share')) {
                     return this.emit(WebcastEvent.SHARE, data);
                 }
 
@@ -607,12 +608,20 @@ export class TikTokLiveConnection extends (EventEmitter as new () => TypedEventE
 
                 return this.emit(WebcastEvent.GIFT, data);
             case 'WebcastBarrageMessage':
-
-                if (data.content?.displayType?.includes('ttlive_superFan')) {
+                if (data.content?.displayType?.toLowerCase().includes('ttlive_superfan')) {
                     this.emit(WebcastEvent.SUPER_FAN, data);
                 }
 
                 return this.emit(WebcastEvent.BARRAGE, data);
+            case 'WebcastEnvelopeMessage':
+                if (
+                    data.common?.displayText?.displayType?.toLowerCase().includes('ttlive_superfanbox')
+                    || data.envelopeInfo?.businessType === EnvelopeBusinessType.BusinessTypeSuperFanBox
+                ) {
+                    this.emit(WebcastEvent.SUPER_FAN_BOX, data);
+                }
+
+                return this.emit(WebcastEvent.ENVELOPE, data);
             default:
 
                 // Handle all other events
@@ -639,5 +648,3 @@ export class TikTokLiveConnection extends (EventEmitter as new () => TypedEventE
     }
 
 }
-
-

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -93,6 +93,7 @@ export enum WebcastEvent {
 
     // Added 2.0.8-beta1
     SUPER_FAN = 'superFan',
+    SUPER_FAN_BOX = 'superFanBox',
 }
 
 
@@ -109,9 +110,9 @@ export type ClientEventMap = {
     // Custom Events
     [WebcastEvent.FOLLOW]: EventHandler<WebcastSocialMessage>,
     [WebcastEvent.SUPER_FAN]: EventHandler<WebcastBarrageMessage>,
+    [WebcastEvent.SUPER_FAN_BOX]: EventHandler<WebcastEnvelopeMessage>,
     [WebcastEvent.SHARE]: EventHandler<WebcastSocialMessage>,
     [WebcastEvent.STREAM_END]: (event: { action: ControlAction }) => void | Promise<void>,
-    [WebcastEvent.SUPER_FAN]: EventHandler<WebcastBarrageMessage>,
 
     // Control Events
     [ControlEvent.CONNECTED]: EventHandler<TikTokLiveConnectionState>,

--- a/src/types/tiktok-schema.ts
+++ b/src/types/tiktok-schema.ts
@@ -227,6 +227,7 @@ export enum EnvelopeBusinessType {
   BusinessTypePlatformMerch = 5,
   BusinessTypeEoYDiamond = 6,
   BusinessTypeFanClubGtM = 7,
+  BusinessTypeSuperFanBox = 19,
   UNRECOGNIZED = -1,
 }
 


### PR DESCRIPTION
This:
- Adds superFan and superFanBox to the list of WebCastEvents in the README
- Adds support for SuperFanBox WebCastEnvelopeMessage type, and emits an event based on it

Other small changes:
- Removed unused import `WebcastBarrageMessage` in `client.ts` (And `EnvelopeBusinessType` is added in it's stead)
- Added `.DS_Store` to `.gitignore` (I will be making more PRs in the near future, so it'll be nice not having to manually exclude it from commits)