### PR TITLE
Adding Support for Super Fan Box to LEGACY API

### DIFF
--- a/src/lib/_legacy/legacy-client.ts
+++ b/src/lib/_legacy/legacy-client.ts
@@ -1,4 +1,8 @@
-import { BaseProtoMessage, ProtoMessageFetchResult, WebcastControlMessage } from '@/types/tiktok-schema';
+import {
+    BaseProtoMessage,
+    ProtoMessageFetchResult,
+    WebcastControlMessage
+} from '@/types/tiktok-schema';
 import { EventEmitter } from 'node:events';
 import { simplifyObject } from '@/lib/_legacy/data-converter';
 import { TikTokLiveConnection } from '@/lib';
@@ -77,8 +81,23 @@ export class WebcastPushConnection extends (TikTokLiveConnection as new (...args
                     case 'WebcastEmoteChatMessage':
                         this.emit(WebcastEvent.EMOTE, simplifiedObj);
                         break;
+                    case 'WebcastBarrageMessage':
+                        this.emit(WebcastEvent.BARRAGE, simplifiedObj);
+                        if (
+                            simplifiedObj.content?.displayType?.toLowerCase()?.includes('ttlive_superfan')
+                            || simplifiedObj.displayType?.toLowerCase()?.includes('ttlive_superfan')
+                        ) {
+                            this.emit(WebcastEvent.SUPER_FAN, simplifiedObj);
+                        }
+                        break;
                     case 'WebcastEnvelopeMessage':
                         this.emit(WebcastEvent.ENVELOPE, simplifiedObj);
+                        if (
+                            simplifiedObj.displayType?.toLowerCase()?.includes('ttlive_superfanbox')
+                            || simplifiedObj.envelopeInfo?.businessType === 19
+                        ) {
+                            this.emit(WebcastEvent.SUPER_FAN_BOX, simplifiedObj);
+                        }
                         break;
                 }
             });
@@ -86,4 +105,3 @@ export class WebcastPushConnection extends (TikTokLiveConnection as new (...args
 
 
 }
-

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -93,6 +93,7 @@ export enum WebcastEvent {
 
     // Added 2.0.8-beta1
     SUPER_FAN = 'superFan',
+    SUPER_FAN_BOX = 'superFanBox',
 }
 
 
@@ -109,9 +110,9 @@ export type ClientEventMap = {
     // Custom Events
     [WebcastEvent.FOLLOW]: EventHandler<WebcastSocialMessage>,
     [WebcastEvent.SUPER_FAN]: EventHandler<WebcastBarrageMessage>,
+    [WebcastEvent.SUPER_FAN_BOX]: EventHandler<WebcastEnvelopeMessage>,
     [WebcastEvent.SHARE]: EventHandler<WebcastSocialMessage>,
     [WebcastEvent.STREAM_END]: (event: { action: ControlAction }) => void | Promise<void>,
-    [WebcastEvent.SUPER_FAN]: EventHandler<WebcastBarrageMessage>,
 
     // Control Events
     [ControlEvent.CONNECTED]: EventHandler<TikTokLiveConnectionState>,


### PR DESCRIPTION
You can choose to include this if you want. I don't need it as I am migrating off the Legacy `WebcastPushConnection` API.

Not sure how many people are still depending on the Legacy API, but this would prevent them from needing to switch from `WebcastPushConnection` -> `TikTokLiveConnection` to access SUPER_FAN and SUPER_FAN_BOX events.

I did not include README.md changes in this as they are included in https://github.com/zerodytrash/TikTok-Live-Connector/pull/308

