### PR TITLE
Distinguish Super Fan Joined from New Super Fan event

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ connection.on(ControlEvent.CONNECTED, () => console.log("Connected!"));
 - [`WebcastEvent.LINK_MIC_ARMIES`](#linkmicarmies) or `"linkMicArmies"`
 - [`WebcastEvent.LIVE_INTRO`](#liveintro) or `"liveIntro"`
 - [`WebcastEvent.SUPER_FAN`](#superfan) or `"superFan"`
+- [`WebcastEvent.SUPER_FAN_JOIN`](#superfanjoin) or `"superFanJoin"`
 - [`WebcastEvent.FOLLOW`](#follow) or `"follow"`
 - [`WebcastEvent.SHARE`](#share) or `"share"`
 - [`WebcastEvent.STREAM_END`](#streamend) or `"streamEnd"`
@@ -329,7 +330,6 @@ connection.on(ControlEvent.CONNECTED, () => console.log("Connected!"));
 - [`WebcastEvent.ROOM_VERIFY`](#roomverify) or `"roomVerify"`
 - [`WebcastEvent.LINK_LAYER`](#linklayer) or `"linkLayer"`
 - [`WebcastEvent.ROOM_PIN`](#roompin) or `"roomPin"`
-- [`WebcastEvent.SUPER_FAN`](#superfan) or `"superFan"`
 - [`WebcastEvent.SUPER_FAN_BOX`](#superfanbox) or `"superFanBox"`
 
 ## Control Events
@@ -690,6 +690,21 @@ Triggers when a user becomes a Super Fan.
 
 ```ts
 connection.on(WebcastEvent.SUPER_FAN, (data) => {
+    if (data.content?.defaultPattern) {
+        console.log(data.content.defaultPattern);
+    }
+    if (data.commonBarrageContent?.defaultPattern) {
+        console.log(data.commonBarrageContent.defaultPattern);
+    }
+});
+```
+
+### `superFanJoin`
+
+Triggers when an existing Super Fan joins the live.
+
+```ts
+connection.on(WebcastEvent.SUPER_FAN_JOIN, (data) => {
     if (data.content?.defaultPattern) {
         console.log(data.content.defaultPattern);
     }

--- a/src/lib/_legacy/legacy-client.ts
+++ b/src/lib/_legacy/legacy-client.ts
@@ -9,6 +9,25 @@ import { TikTokLiveConnection } from '@/lib';
 import { ControlEvent, WebcastEvent } from '@/types/events';
 import { WebcastEventMessage } from '@/types';
 
+function resolveLegacySuperFanBarrageEvent(data: Record<string, any>): WebcastEvent.SUPER_FAN | WebcastEvent.SUPER_FAN_JOIN | null {
+    const displayTypes = [
+        data.content?.displayType,
+        data.displayType,
+    ]
+        .filter((value): value is string => typeof value === 'string' && value.length > 0)
+        .map((value) => value.toLowerCase());
+
+    if (displayTypes.some((value) => value.includes('ttlive_superfan_commentnotif_superfanjoined'))) {
+        return WebcastEvent.SUPER_FAN_JOIN;
+    }
+
+    if (displayTypes.some((value) => value.includes('ttlive_superfan_commentnotif_someonebecamesuperfan'))) {
+        return WebcastEvent.SUPER_FAN;
+    }
+
+    return null;
+}
+
 /**
  * The legacy WebcastPushConnection class for backwards compatibility.
  * @deprecated Use TikTokLiveConnection instead.
@@ -83,11 +102,11 @@ export class WebcastPushConnection extends (TikTokLiveConnection as new (...args
                         break;
                     case 'WebcastBarrageMessage':
                         this.emit(WebcastEvent.BARRAGE, simplifiedObj);
-                        if (
-                            simplifiedObj.content?.displayType?.toLowerCase()?.includes('ttlive_superfan')
-                            || simplifiedObj.displayType?.toLowerCase()?.includes('ttlive_superfan')
-                        ) {
-                            this.emit(WebcastEvent.SUPER_FAN, simplifiedObj);
+                        {
+                            const superFanEvent = resolveLegacySuperFanBarrageEvent(simplifiedObj);
+                            if (superFanEvent) {
+                                this.emit(superFanEvent, simplifiedObj);
+                            }
                         }
                         break;
                     case 'WebcastEnvelopeMessage':

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -42,6 +42,28 @@ type SendMessageOptions = {
     oauthToken?: string;
 };
 
+function resolveSuperFanBarrageEvent(data: {
+    content?: { displayType?: string } | undefined;
+    commonBarrageContent?: { displayType?: string } | undefined;
+}): WebcastEvent.SUPER_FAN | WebcastEvent.SUPER_FAN_JOIN | null {
+    const displayTypes = [
+        data.content?.displayType,
+        data.commonBarrageContent?.displayType,
+    ]
+        .filter((value): value is string => typeof value === 'string' && value.length > 0)
+        .map((value) => value.toLowerCase());
+
+    if (displayTypes.some((value) => value.includes('ttlive_superfan_commentnotif_superfanjoined'))) {
+        return WebcastEvent.SUPER_FAN_JOIN;
+    }
+
+    if (displayTypes.some((value) => value.includes('ttlive_superfan_commentnotif_someonebecamesuperfan'))) {
+        return WebcastEvent.SUPER_FAN;
+    }
+
+    return null;
+}
+
 
 export class TikTokLiveConnection extends (EventEmitter as new () => TypedEventEmitter<ClientEventMap>) {
 
@@ -606,8 +628,11 @@ export class TikTokLiveConnection extends (EventEmitter as new () => TypedEventE
 
                 return this.emit(WebcastEvent.GIFT, data);
             case 'WebcastBarrageMessage':
-                if (data.content?.displayType?.toLowerCase().includes('ttlive_superfan')) {
-                    this.emit(WebcastEvent.SUPER_FAN, data);
+                {
+                    const superFanEvent = resolveSuperFanBarrageEvent(data);
+                    if (superFanEvent) {
+                        this.emit(superFanEvent, data);
+                    }
                 }
 
                 return this.emit(WebcastEvent.BARRAGE, data);

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -93,6 +93,7 @@ export enum WebcastEvent {
 
     // Added 2.0.8-beta1
     SUPER_FAN = 'superFan',
+    SUPER_FAN_JOIN = 'superFanJoin',
     SUPER_FAN_BOX = 'superFanBox',
 }
 
@@ -110,6 +111,7 @@ export type ClientEventMap = {
     // Custom Events
     [WebcastEvent.FOLLOW]: EventHandler<WebcastSocialMessage>,
     [WebcastEvent.SUPER_FAN]: EventHandler<WebcastBarrageMessage>,
+    [WebcastEvent.SUPER_FAN_JOIN]: EventHandler<WebcastBarrageMessage>,
     [WebcastEvent.SUPER_FAN_BOX]: EventHandler<WebcastEnvelopeMessage>,
     [WebcastEvent.SHARE]: EventHandler<WebcastSocialMessage>,
     [WebcastEvent.STREAM_END]: (event: { action: ControlAction }) => void | Promise<void>,


### PR DESCRIPTION
TikTok is now emitting another event with `superfan` in the display type. This event is called `superFanJoined`.

Because of how the current `superFan` event is detected (basically by checking if the Barrage Event contains the text "superfan"), these new Join events are causing superFan events to trigger erroneously.

Here's a payload from a Super Fan event in my own live today:

```
"2026-04-22 10:42:53.573609"	
"USERNAME REDACTED"	
"DISPLAY NAME REDACTED"	
"100"	
"BecomingSuperFanLv10"	
"ttlive_superFan_commentNotif_someoneBecameSuperFan"	
"ttlive_superFan_commentNotif_someoneBecameSuperFan"	
"{0:user} just became a Super Fan"	
"{0:user} just became a Super Fan"
```

Here's a payload from a Super Fan Join Event in my own live today:

```
"2026-04-22 10:49:01.304617"
"USERNAME REDACTED"	
"DISPLAYNAME REDACTED"	
"11"	
"fans_entrance"	
"ttlive_superFan_commentNotif_superFanJoined"	
"ttlive_superFan_commentNotif_superFanJoined"	
"Super Fan {0:user} joined"	
"Super Fan {0:user} joined"
```

As you can see, the difference is `someoneBecameSuperFan` vs. `superFanJoined` on the Display Type. We will now distinguish the events by using more strict checks for the name in the `displayType`.

This is the logical basis for this PR and what it is attempting to solve.