### PR TITLE
Preserve Euler rate-limit response headers

### DIFF
--- a/src/lib/web/routes/euler/fetch-signed-websocket-euler.ts
+++ b/src/lib/web/routes/euler/fetch-signed-websocket-euler.ts
@@ -120,7 +120,7 @@ export const fetchSignedWebSocketFromEulerRoute = createRoute<FetchSignedWebSock
             const data = JSON.parse(Buffer.from(response.data).toString('utf-8')) as any;
             const message = process.env.SIGN_SERVER_MESSAGE_DISABLED ? null : data?.message;
             const label = data?.limit_label ? `(${data.limit_label}) ` : '';
-            throw new SignatureRateLimitError(message, `${label}Too many connections started, try again later.`, response.data);
+            throw new SignatureRateLimitError(message, `${label}Too many connections started, try again later.`, response);
         }
 
         if (response.status === 402) {

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -3,7 +3,7 @@
  * Avoids depending on axios's declaration files (which the library no longer ships at runtime).
  */
 type RateLimitedResponse = {
-    headers: Record<string, string | undefined>;
+    headers: Record<string, unknown>;
 };
 
 class ConnectError extends Error {
@@ -135,8 +135,8 @@ export class SignatureRateLimitError extends SignAPIError {
     constructor(apiMessage: string | undefined, formatStr: string, response: RateLimitedResponse) {
         const retryAfter = SignatureRateLimitError.calculateRetryAfter(response);
         const resetTime = SignatureRateLimitError.calculateResetTime(response);
-        const logId = response.headers['x-log-id'];
-        const agentId = response.headers['x-agent-id'];
+        const logId = SignatureRateLimitError.readHeader(response, 'x-log-id');
+        const agentId = SignatureRateLimitError.readHeader(response, 'x-agent-id');
 
         const formattedMsg = formatStr.replace('%s', retryAfter.toString());
         const args: string[] = [formattedMsg];
@@ -152,17 +152,18 @@ export class SignatureRateLimitError extends SignAPIError {
         this.resetTime = resetTime;
     }
 
-    private static parseHeaderNumber(value: string | undefined): number | undefined {
-        return value ? parseInt(value) : undefined;
+    private static readHeader(response: RateLimitedResponse, name: string): string | undefined {
+        const value = response.headers[name];
+        return typeof value === 'string' || typeof value === 'number' ? String(value) : undefined;
     }
 
     private static calculateRetryAfter(response: RateLimitedResponse): number {
-        const retryAfter = parseInt(response.headers['retry-after'] || '0');
+        const retryAfter = parseInt(SignatureRateLimitError.readHeader(response, 'retry-after') || '0');
         return retryAfter * 1000;
     }
 
     private static calculateResetTime(response: RateLimitedResponse): number | undefined {
-        const value = response.headers['x-ratelimit-reset'];
+        const value = SignatureRateLimitError.readHeader(response, 'x-ratelimit-reset');
         return value ? parseInt(value) * 1000 : undefined;
     }
 

--- a/test/lib/factories.ts
+++ b/test/lib/factories.ts
@@ -1,4 +1,4 @@
-import type WebcastHttpClient from '@/lib/web/lib/http-client';
+import type { WebcastHttpClient } from '@/lib/web/lib/http-client';
 import type { CookieSessionBundle, OAuthTokenSessionBundle } from '@/types/client';
 import type EulerStreamApiClient from 'tiktok-live-api-sdk';
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';

--- a/test/routes/euler/fetch-signed-websocket-euler.test.ts
+++ b/test/routes/euler/fetch-signed-websocket-euler.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ErrorReason, SignatureRateLimitError } from '@/types/errors';
+import { fetchSignedWebSocketFromEulerRoute } from '@/lib/web/routes/euler/fetch-signed-websocket-euler';
+import { createAxiosResponse, createMockEulerClient, createMockWebClient, TEST_ROOM_ID } from '../../lib';
+
+describe('fetchSignedWebSocketFromEulerRoute', () => {
+    it.each([
+        {
+            description: 'preserves retry and diagnostic headers',
+            headers: {
+                'retry-after': '30',
+                'x-ratelimit-reset': '2000000000',
+                'x-log-id': 'test-request-id',
+                'x-agent-id': 'test-agent-id'
+            },
+            expected: {
+                retryAfter: 30_000,
+                resetTime: 2_000_000_000_000,
+                requestId: 'test-request-id',
+                agentId: 'test-agent-id'
+            }
+        },
+        {
+            description: 'accepts numeric retry headers',
+            headers: {
+                'retry-after': 30,
+                'x-ratelimit-reset': 2_000_000_000
+            },
+            expected: {
+                retryAfter: 30_000,
+                resetTime: 2_000_000_000_000,
+                requestId: undefined,
+                agentId: undefined
+            }
+        },
+        {
+            description: 'handles a rate limit without optional headers',
+            headers: {},
+            expected: {
+                retryAfter: 0,
+                resetTime: undefined,
+                requestId: undefined,
+                agentId: undefined
+            }
+        }
+    ])('$description', async ({ headers, expected }) => {
+        vi.stubEnv('SIGN_SERVER_MESSAGE_DISABLED', '');
+        const webClient = createMockWebClient();
+        const apiClient = createMockEulerClient();
+        apiClient.rooms.fetchWebcastURL.mockResolvedValue(createAxiosResponse(
+            Buffer.from(JSON.stringify({
+                message: 'Synthetic signing quota exceeded.',
+                limit_label: 'minute'
+            })),
+            { status: 429, headers }
+        ));
+
+        const result = fetchSignedWebSocketFromEulerRoute({
+            webClient,
+            apiClient,
+            roomId: TEST_ROOM_ID
+        });
+
+        await expect(result).rejects.toBeInstanceOf(SignatureRateLimitError);
+        await expect(result).rejects.toMatchObject({
+            reason: ErrorReason.RATE_LIMIT,
+            ...expected,
+            message: expect.stringContaining('(minute) Too many connections started')
+        });
+        await expect(result).rejects.toThrow('Synthetic signing quota exceeded.');
+        expect(apiClient.rooms.fetchWebcastURL).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
This fixes the Typing issue documented in #330 

See the diff for explanations of other somewhat unrelated fixes (mostly needed to get tests to pass). Test added as well.